### PR TITLE
Run tests async instead of sync

### DIFF
--- a/test/ci/mix/check_test.exs
+++ b/test/ci/mix/check_test.exs
@@ -1,6 +1,5 @@
 defmodule Mix.Tasks.Ci.CheckTest do
-  # sync because of IO capture
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   alias Mix.Tasks.Ci.Check
 
   test "performs all checks" do

--- a/test/job/pipeline_test.exs
+++ b/test/job/pipeline_test.exs
@@ -1,6 +1,5 @@
 defmodule Job.PipelineTest do
-  # sync because of log capture
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Job.Pipeline
 

--- a/test/job_test.exs
+++ b/test/job_test.exs
@@ -1,6 +1,5 @@
 defmodule JobTest do
-  # sync because of log capture
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   describe "job" do
     test "stops when the given function finishes" do

--- a/test/os_cmd_test.exs
+++ b/test/os_cmd_test.exs
@@ -1,6 +1,5 @@
 defmodule OsCmdTest do
-  # sync because of log capture
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   with {:error, _} <- OsCmd.Port.executable(), do: @moduletag(skip: true)
 


### PR DESCRIPTION
Since Elixir 1.11 it's been safe to run async tests where you're using
`capture_log` and `capture_io`. The only downside is that - while it is
per process capturing - multiple processes can have their IO or log
output mixed together (only with mixed lines, not any mixes within a
given line), and so assertions on these captures usually need to be
Regexes and not `==` on expected strings.