### PR TITLE
Fix issue where hex package does not build

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule Ci.MixProject do
       description: "CI/CD toolkit as an Elixir library",
       maintainers: ["Saša Jurić"],
       licenses: ["MIT"],
+      files: ~w(lib priv .formatter.exs mix.exs README* LICENSE* CHANGELOG* ports),
       links: %{
         "Github" => "https://github.com/sasa1977/ci",
         "Changelog" =>


### PR DESCRIPTION
The directory `ports` is not one of the default directories that
hex will include:
https://hexdocs.pm/hex/Mix.Tasks.Hex.Build.html#module-package-configuration

This commit changes that to use src which is a default.