### PR TITLE
initial sidekick implementation

### DIFF
--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -55,7 +55,6 @@ defmodule Sidekick do
 
   defp start_node_command(sidekick_node) do
     {:ok, command} = :init.get_argument(:progname)
-    paths = Enum.join(:code.get_path(), " , ")
 
     base_args = "-noinput -name #{sidekick_node}"
 
@@ -65,11 +64,11 @@ defmodule Sidekick do
     cookie = Node.get_cookie()
     cookie_arg = "-setcookie #{cookie}"
 
-    paths_arg = "-pa #{paths}"
+    paths_args = :code.get_path() |> Enum.map(&"-pa #{&1}") |> Enum.join(" ")
 
     command_args = "-s Elixir.Sidekick start_sidekick #{node()}"
 
-    args = "#{base_args} #{boot_file_args} #{cookie_arg} #{paths_arg} #{command_args}"
+    args = "#{base_args} #{boot_file_args} #{cookie_arg} #{paths_args} #{command_args}"
 
     "#{command} #{args}"
   end

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -3,7 +3,7 @@ defmodule Sidekick do
   def start(node_name \\ :docker, children) do
     ensure_distributed!()
 
-    node = node_host_name(node_name)
+    node = :"#{node_name}@#{hostname()}"
 
     case Node.ping(node) do
       :pang -> wait_for_sidekick(node, children)
@@ -30,9 +30,9 @@ defmodule Sidekick do
       do: :init.stop()
   end
 
-  defp node_host_name(name) do
-    hostname = Node.self() |> Atom.to_string() |> String.split("@") |> List.last()
-    :"#{name}@#{hostname}"
+  defp hostname do
+    [_name, hostname] = String.split("#{node()}", "@", parts: 2)
+    hostname
   end
 
   defp wait_for_sidekick(sidekick_node, children) do

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -26,7 +26,7 @@ defmodule Sidekick do
   @doc false
   def sidekick_init([parent_node]) do
     if Node.connect(parent_node) in [false, :ignored],
-      do: :init.stop()
+      do: System.stop()
   end
 
   defp hostname do

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -17,8 +17,8 @@ defmodule Sidekick do
   @spec start_sidekick([node]) :: :ok
   @doc false
   def start_sidekick([parent_node]) do
-    Node.connect(parent_node)
-    :ok
+    if Node.connect(parent_node) in [false, :ignored],
+      do: :init.stop()
   end
 
   defp node_host_name(name) do

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -1,5 +1,5 @@
 defmodule Sidekick do
-  @spec start(atom, [{atom, any}]) :: {:error, any} | :ok
+  @spec start(atom, [Parent.child_spec()]) :: :ok | {:error, :already_started | :boot_error}
   def start(node_name \\ :docker, children) do
     ensure_distributed!()
 
@@ -55,7 +55,7 @@ defmodule Sidekick do
     receive do
       # {:nodeup, ^sidekick_node} -> :ok
       {__MODULE__, :initialized} -> :ok
-      {^port, {:exit_status, status}} -> {:error, {:node_stopped, status}}
+      {^port, {:exit_status, _status}} -> {:error, :boot_error}
     end
   end
 

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -25,8 +25,11 @@ defmodule Sidekick do
 
   @doc false
   def sidekick_init([parent_node]) do
-    if Node.connect(parent_node) in [false, :ignored],
-      do: System.stop()
+    with {:ok, _} <- Application.ensure_all_started(:elixir),
+         {:ok, _} <- Application.ensure_all_started(:parent),
+         true <- Node.connect(parent_node),
+         do: :ok,
+         else: (_ -> System.stop())
   end
 
   defp hostname do

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -1,0 +1,81 @@
+defmodule Sidekick do
+  @spec start(atom, [{atom, any}]) :: {:error, any} | {:ok, atom, pid}
+  def start(node_name \\ :docker, children \\ [{Ci.Docker, []}]) do
+    parent_node = Node.self()
+    node = node_host_name(node_name)
+
+    case Node.ping(node) do
+      :pang -> wait_for_sidekick(node, parent_node, children)
+      :pong -> {:error, "Sidekick node #{node} is already alive"}
+    end
+  end
+
+  @spec call(atom, atom, atom, list) :: any
+  def call(name \\ :docker, module, function, args) do
+    :rpc.block_call(node_host_name(name), module, function, args)
+  end
+
+  @spec cast(atom, atom, atom, list) :: true
+  def cast(name \\ :docker, module, function, args) do
+    :rpc.cast(node_host_name(name), module, function, args)
+  end
+
+  @spec start_sidekick([node]) :: :ok
+  def start_sidekick([parent_node]) do
+    Node.connect(parent_node)
+    :ok
+  end
+
+  defp node_host_name(name) do
+    hostname = Node.self() |> Atom.to_string() |> String.split("@") |> List.last()
+    :"#{name}@#{hostname}"
+  end
+
+  defp wait_for_sidekick(sidekick_node, parent_node, children) do
+    :net_kernel.monitor_nodes(true)
+    command = start_node_command(sidekick_node, parent_node)
+    Port.open({:spawn, command}, [:stream])
+
+    receive do
+      {:nodeup, ^sidekick_node} ->
+        # wait for node to really be up
+        # TODO deal with this in a better way
+        :timer.sleep(500)
+
+        case call(:docker, Sidekick.Supervisor, :start_link, [[parent_node, children]]) do
+          {:ok, pid} ->
+            {:ok, sidekick_node, pid}
+
+          {:error, error} ->
+            Node.spawn(sidekick_node, :init, :stop, [])
+            {:error, error}
+        end
+    after
+      5000 ->
+        # Shutdown node if we never received a response
+        Node.spawn(sidekick_node, :init, :stop, [])
+        {:error, :timeout}
+    end
+  end
+
+  defp start_node_command(sidekick_node, parent_node) do
+    {:ok, command} = :init.get_argument(:progname)
+    paths = Enum.join(:code.get_path(), " , ")
+
+    base_args = "-noinput -name #{sidekick_node}"
+
+    priv_dir = :code.priv_dir(:ci)
+    boot_file_args = "-boot #{priv_dir}/node"
+
+    cookie = Node.get_cookie()
+    cookie_arg = "-setcookie #{cookie}"
+
+    paths_arg = "-pa #{paths}"
+
+    command_args = "-s Elixir.Sidekick start_sidekick #{parent_node}"
+
+    args = "#{base_args} #{boot_file_args} #{cookie_arg} #{paths_arg} #{command_args}"
+
+    "#{command} #{args}"
+  end
+end

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -1,6 +1,6 @@
 defmodule Sidekick do
   @spec start(atom, [Parent.child_spec()]) :: :ok | {:error, :already_started | :boot_error}
-  def start(node_name \\ :docker, children) do
+  def start(node_name, children) do
     ensure_distributed!()
 
     node = :"#{node_name}@#{hostname()}"

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -1,5 +1,5 @@
 defmodule Sidekick do
-  @spec start(atom, [{atom, any}]) :: {:error, any} | {:ok, atom, pid}
+  @spec start(atom, [{atom, any}]) :: {:error, any} | :ok
   def start(node_name \\ :docker, children) do
     ensure_distributed!()
 

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -22,7 +22,7 @@ defmodule Sidekick do
   end
 
   @doc false
-  def start_sidekick([parent_node]) do
+  def sidekick_init([parent_node]) do
     if Node.connect(parent_node) in [false, :ignored],
       do: :init.stop()
   end
@@ -66,7 +66,7 @@ defmodule Sidekick do
 
     paths_args = :code.get_path() |> Enum.map(&"-pa #{&1}") |> Enum.join(" ")
 
-    command_args = "-s Elixir.Sidekick start_sidekick #{node()}"
+    command_args = "-s Elixir.Sidekick sidekick_init #{node()}"
 
     args = "#{base_args} #{boot_file_args} #{cookie_arg} #{paths_args} #{command_args}"
 

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -13,6 +13,8 @@ defmodule Sidekick do
   end
 
   defp ensure_distributed! do
+    System.cmd("epmd", ["-daemon"])
+
     node_name = :crypto.strong_rand_bytes(16) |> Base.encode32(padding: false, case: :lower)
 
     case :net_kernel.start([:"#{node_name}@127.0.0.1"]) do

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -29,12 +29,10 @@ defmodule Sidekick do
       |> Base.decode32!(padding: false)
       |> :erlang.binary_to_term()
 
-    with {:ok, _} <- Application.ensure_all_started(:elixir),
-         {:ok, _} <- Application.ensure_all_started(:parent),
-         {:ok, _} <- Sidekick.Supervisor.start_link(parent_node, children),
-         true <- Node.connect(parent_node),
-         do: :ok,
-         else: (_ -> System.stop())
+    {:ok, _} = Application.ensure_all_started(:elixir)
+    {:ok, _} = Application.ensure_all_started(:parent)
+    {:ok, _} = Sidekick.Supervisor.start_link(parent_node, children)
+    true = Node.connect(parent_node)
   end
 
   defp hostname do

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -62,7 +62,14 @@ defmodule Sidekick do
   defp start_node_command(sidekick_node, children) do
     {:ok, command} = :init.get_argument(:progname)
 
-    base_args = "-noinput -name #{sidekick_node}"
+    name_arg =
+      case :net_kernel.longnames() do
+        true -> "-name #{sidekick_node}"
+        false -> "-sname #{sidekick_node}"
+        _ -> raise "not in distributed mode"
+      end
+
+    base_args = "-noinput #{name_arg}"
 
     priv_dir = :code.priv_dir(:ci)
     boot_file_args = "-boot #{priv_dir}/node"

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -35,7 +35,7 @@ defmodule Sidekick do
     parent_node = node(caller)
     true = Node.connect(parent_node)
 
-    {:ok, _} = Sidekick.Supervisor.start_link(parent_node, children)
+    {:ok, _} = Sidekick.Supervisor.start(parent_node, children)
 
     send(caller, {__MODULE__, :initialized})
   end

--- a/lib/sidekick/sidekick.ex
+++ b/lib/sidekick/sidekick.ex
@@ -14,7 +14,6 @@ defmodule Sidekick do
     :rpc.block_call(node, module, function, args)
   end
 
-  @spec start_sidekick([node]) :: :ok
   @doc false
   def start_sidekick([parent_node]) do
     if Node.connect(parent_node) in [false, :ignored],

--- a/lib/sidekick/sidekick_supervisor.ex
+++ b/lib/sidekick/sidekick_supervisor.ex
@@ -1,0 +1,41 @@
+defmodule Sidekick.Supervisor do
+  use Parent.GenServer
+  require Logger
+
+  @spec start_link([...]) :: GenServer.on_start()
+  def start_link([parent_node, children]) do
+    Parent.GenServer.start_link(__MODULE__, [parent_node, children], name: __MODULE__)
+  end
+
+  @impl true
+  @spec init([...]) :: {:ok, nil} | {:stop, {:shutdown, :could_not_start_all_children}}
+  def init([parent_node, children]) do
+    Node.monitor(parent_node, true)
+
+    all_started =
+      Enum.map(children, fn spec -> Parent.start_child(spec) end)
+      |> Enum.all?(&({:ok, _pid} = &1))
+
+    if all_started do
+      {:ok, nil}
+    else
+      Parent.shutdown_all()
+      {:stop, {:shutdown, :could_not_start_all_children}}
+    end
+  end
+
+  @impl true
+  def handle_info({:nodedown, _node}, state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:EXIT, _pid, _reason}, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    Logger.debug("Termination #{__MODULE__}")
+    Parent.shutdown_all()
+    :init.stop()
+    state
+  end
+end

--- a/lib/sidekick/sidekick_supervisor.ex
+++ b/lib/sidekick/sidekick_supervisor.ex
@@ -2,7 +2,7 @@ defmodule Sidekick.Supervisor do
   use Parent.GenServer
   require Logger
 
-  @spec start(atom, [...]) :: GenServer.on_start()
+  @spec start(node, [Parent.child_spec()]) :: GenServer.on_start()
   def start(parent_node, children) do
     # We're calling `start_link` but under the hood this will behave like `start`. See `init/1` for details.
     Parent.GenServer.start_link(__MODULE__, {self(), parent_node, children}, name: __MODULE__)

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,10 @@ defmodule Ci.MixProject do
 
   defp get_version(app) do
     path = :code.lib_dir(app)
-    {:ok, [{:application, ^app, properties}]} = :file.consult(Path.join(path, "ebin/#{app}.app"))
+
+    {:ok, [{:application, ^app, properties}]} =
+      :file.consult(Path.join([path, "ebin/#{app}.app"]))
+
     Keyword.fetch!(properties, :vsn)
   end
 

--- a/priv/.gitignore
+++ b/priv/.gitignore
@@ -1,2 +1,6 @@
 /os_cmd
 /pty
+
+node.script
+node.rel
+node.boot

--- a/test/sidekick_test.exs
+++ b/test/sidekick_test.exs
@@ -1,8 +1,7 @@
 defmodule SidekickTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
-  test "foo" do
-    Sidekick.start([]) |> IO.inspect()
-    assert_receive :foo
+  test "starts a remote node" do
+    assert Sidekick.start([]) == :ok
   end
 end

--- a/test/sidekick_test.exs
+++ b/test/sidekick_test.exs
@@ -2,6 +2,19 @@ defmodule SidekickTest do
   use ExUnit.Case, async: false
 
   test "starts a remote node" do
-    assert Sidekick.start([]) == :ok
+    assert Sidekick.start(:test, []) == :ok
+
+    # Sidekick node should exist
+    assert Node.list() == [:"test@127.0.0.1"]
+
+    # Supervisor should be started on the Node
+    pid = GenServer.whereis({Sidekick.Supervisor, :"test@127.0.0.1"})
+    assert pid != nil
+
+    # Shutting down the supervisor should close down the node
+    Node.monitor(:"test@127.0.0.1", true)
+    Supervisor.stop(pid)
+    assert_receive {:nodedown, :"test@127.0.0.1"}, 2000
+    assert Node.list() == []
   end
 end

--- a/test/sidekick_test.exs
+++ b/test/sidekick_test.exs
@@ -1,0 +1,8 @@
+defmodule SidekickTest do
+  use ExUnit.Case
+
+  test "foo" do
+    Sidekick.start([]) |> IO.inspect()
+    assert_receive :foo
+  end
+end


### PR DESCRIPTION
## Sidekick implementation

I took most of the code from the prototype, but have changed the way we start the supervisor on the sidekick node. Instead of passing it as an argument to `erl`. We start it separately after the node has come up. (Added a todo because at the moment it seems even after we get the `nodeup`, the node might not be fully ready)

Added a parent supervisor instead of the naive docker implementation and moved the `parent_node` monitoring to this.

Still a bit new to using `specs`, so there might be some improvements needed there.
Let me know what you think 
