### PR TITLE
Update dependencies to support MacOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Restore cached deps
         uses: actions/cache@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 24.0.6
 elixir 1.12.3-otp-24
-golang 1.15
+golang 1.16

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ end)
 
     - Erlang >= 23
     - Elixir >= 1.11
-    - go >= 1.15
+    - go >= 1.16
 
 2. Add CI as a dependency inside your `mix.exs`:
 

--- a/ports/os_cmd/go.mod
+++ b/ports/os_cmd/go.mod
@@ -2,4 +2,4 @@ module sasa1977/os_cmd
 
 go 1.16
 
-require github.com/creack/pty v1.1.11
+require github.com/creack/pty v1.1.20

--- a/ports/os_cmd/go.mod
+++ b/ports/os_cmd/go.mod
@@ -1,5 +1,5 @@
 module sasa1977/os_cmd
 
-go 1.15
+go 1.16
 
 require github.com/creack/pty v1.1.11

--- a/ports/os_cmd/go.sum
+++ b/ports/os_cmd/go.sum
@@ -1,2 +1,4 @@
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.20 h1:VIPb/a2s17qNeQgDnkfZC35RScx+blkKF8GV68n80J4=
+github.com/creack/pty v1.1.20/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=


### PR DESCRIPTION
I discovered that updating the [creack/pty](https://github.com/creack/pty) library fixes the issue in #8 and allows the mix command to work on MacOS. In addition, Go 1.15 is not available for M1 series Macs so I bumped the minimum version to 1.16, which is the earliest version to add support for M1.

I was unsure if I should update the Go version to a more recent version than 1.16. Go officially supports one version behind the latest, which means 1.20 or 1.21 if you'd like to update it. I'll leave that decision to you. 